### PR TITLE
[CORRECTIVE] fix include case

### DIFF
--- a/library/HierarchyView/hierarchyitem.cpp
+++ b/library/HierarchyView/hierarchyitem.cpp
@@ -9,7 +9,7 @@
 // Represents a single component in the library in hierarchy view.
 //-----------------------------------------------------------------------------
 
-#include "HierarchyItem.h"
+#include "hierarchyitem.h"
 
 #include <library/LibraryInterface.h>
 


### PR DESCRIPTION
library/HierarchyView/hierarchyitem.cpp includes HierarchyItem.h
But header file is all lower case instead of camel case.

This case issue generates this build failure at the compile time :
library/HierarchyView/hierarchyitem.cpp:12:27: fatal error: HierarchyItem.h: No such file or directory