### PR TITLE
[CORRECTIVE] Fix references to LibraryInterface.h

### DIFF
--- a/editors/ComponentEditor/fileSet/file/filenamelineedit.cpp
+++ b/editors/ComponentEditor/fileSet/file/filenamelineedit.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "filenamelineedit.h"
-#include <library/LibraryManager/libraryinterface.h>
+#include <library/LibraryInterface.h>
 #include <IPXACTmodels/generaldeclarations.h>
 
 #include <QFileDialog>

--- a/editors/ComponentEditor/treeStructure/componenteditorswviewitem.cpp
+++ b/editors/ComponentEditor/treeStructure/componenteditorswviewitem.cpp
@@ -13,7 +13,7 @@
 
 #include <editors/ComponentEditor/software/swView/SWViewEditor.h>
 
-#include <library/LibraryManager/libraryinterface.h>
+#include <library/LibraryInterface.h>
 
 #include <IPXACTmodels/Component/Component.h>
 #include <IPXACTmodels/kactusExtensions/SWView.h>

--- a/tests/MockObjects/DesignWidgetFactoryMock.h
+++ b/tests/MockObjects/DesignWidgetFactoryMock.h
@@ -15,7 +15,7 @@
 #include <designEditors/common/DesignWidgetFactory.h>
 #include <designEditors/common/DesignWidget.h>
 
-#include <library/libraryinterface.h>
+#include <library/LibraryInterface.h>
 
 //-----------------------------------------------------------------------------
 //! Mock class for constructing design widgets.

--- a/tests/MockObjects/HWDesignWidgetMock.cpp
+++ b/tests/MockObjects/HWDesignWidgetMock.cpp
@@ -16,7 +16,7 @@
 
 #include <common/GenericEditProvider.h>
 
-#include <library/libraryinterface.h>
+#include <library/LibraryInterface.h>
 
 #include <IPXACTmodels/Component/Component.h>
 #include <IPXACTmodels/Component/Model.h>


### PR DESCRIPTION
Seems like some references to the old .h file remained after it was moved. This fixes compilation for me