### PR TITLE
[CORRECTIVE] fix case on include to respect Linux behaviour

### DIFF
--- a/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesEditor.h
+++ b/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesEditor.h
@@ -12,7 +12,7 @@
 #ifndef INDIRECT_INTERFACES_EDITOR_H
 #define INDIRECT_INTERFACES_EDITOR_H
 
-#include "IndirectInterfacesmodel.h"
+#include "IndirectInterfacesModel.h"
 
 #include <common/views/EditableTableView/editabletableview.h>
 

--- a/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp
+++ b/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp
@@ -9,7 +9,7 @@
 // Data model for component indirect interfaces.
 //-----------------------------------------------------------------------------
 
-#include "IndirectInterfacesmodel.h"
+#include "IndirectInterfacesModel.h"
 
 #include "IndirectInterfaceColumns.h"
 

--- a/editors/ComponentEditor/treeStructure/ComponentEditorIndirectInterfacesItem.cpp
+++ b/editors/ComponentEditor/treeStructure/ComponentEditorIndirectInterfacesItem.cpp
@@ -9,10 +9,10 @@
 // The Indirect interfaces -item in the component editor navigation tree.
 //-----------------------------------------------------------------------------
 
-#include "componenteditorIndirectInterfacesitem.h"
+#include "ComponentEditorIndirectInterfacesItem.h"
 #include "SingleIndirectInterfaceItem.h"
 
-#include <editors/ComponentEditor/IndirectInterfaces/IndirectInterfaceseditor.h>
+#include <editors/ComponentEditor/indirectInterfaces/IndirectInterfacesEditor.h>
 
 #include <IPXACTmodels/Component/Component.h>
 #include <IPXACTmodels/Component/validators/IndirectInterfaceValidator.h>

--- a/editors/ComponentEditor/treeStructure/SingleIndirectInterfaceItem.cpp
+++ b/editors/ComponentEditor/treeStructure/SingleIndirectInterfaceItem.cpp
@@ -9,11 +9,11 @@
 // The item for single bus interface in the component editor's navigation tree.
 //-----------------------------------------------------------------------------
 
-#include "SingleIndirectInterfaceitem.h"
+#include "SingleIndirectInterfaceItem.h"
 
 #include <library/LibraryInterface.h>
 
-#include <editors/ComponentEditor/IndirectInterfaces/SingleIndirectInterfaceEditor.h>
+#include <editors/ComponentEditor/indirectInterfaces/SingleIndirectInterfaceEditor.h>
 #include <editors/ComponentEditor/common/ExpressionParser.h>
 
 #include <IPXACTmodels/Component/IndirectInterface.h>

--- a/mainwindow/DockWidgetHandler.h
+++ b/mainwindow/DockWidgetHandler.h
@@ -12,8 +12,8 @@
 #ifndef DOCKWIDGETHANDLER_H
 #define DOCKWIDGETHANDLER_H
 
-#include <common\utils.h>
-#include <common\widgets\tabDocument\TabDocument.h>
+#include <common/utils.h>
+#include <common/widgets/tabDocument/TabDocument.h>
 
 class LibraryHandler;
 class LibraryWidget;


### PR DESCRIPTION
On Linux, upper/lower case must be respected and '\' characters are specific to Windows OS.
This patch fix wrong include and change '\' to '/'

signed-off-by: Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>