### PR TITLE
[CORRECTIVE] common:graphicsItems:GraphicsConnection: fix extra qualification

### DIFF
--- a/common/graphicsItems/GraphicsConnection.h
+++ b/common/graphicsItems/GraphicsConnection.h
@@ -400,7 +400,7 @@ private:
      *
      *      @return The <min, max> limits for the segment.
      */
-    QPair<qreal, qreal> GraphicsConnection::getSegmentLimitsY(int i) const;
+    QPair<qreal, qreal> getSegmentLimitsY(int i) const;
 
     /*!
      *  Searches for a vertical segment overlap.


### PR DESCRIPTION
on an header file class name must not be set for a member.
This patch fix error :
In file included from common/graphicsItems/ComponentItem.cpp:16:0:
common/graphicsItems/GraphicsConnection.h:403:25: error: extra qualification 'GraphicsConnection::' on member 'getSegmentLimitsY' [-fpermissive]
     QPair<qreal, qreal> GraphicsConnection::getSegmentLimitsY(int i) const;

Signed-off-by: Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>