### PR TITLE
[CORRECTIVE]: IndirectInterfacesModel: fix error expected type-specifier before IndirectInterface

### DIFF
--- a/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp
+++ b/editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp
@@ -314,8 +314,8 @@ void IndirectInterfacesModel::onAddItem(QModelIndex const& index)
 	}
 
 	beginInsertRows(QModelIndex(), row, row);
-    QSharedPointer<IndirectInterface> IndirectInterface(new IndirectInterface());
-    indirectInterfaces_->insert(row, IndirectInterface);
+    QSharedPointer<IndirectInterface> indirectInterface(new IndirectInterface());
+    indirectInterfaces_->insert(row, indirectInterface);
 	endInsertRows();
 
 	emit interfaceAdded(row);


### PR DESCRIPTION
Built fail with :
editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp: In member function 'virtual void IndirectInterfacesModel::onAddItem(const QModelIndex&)':
editors/ComponentEditor/indirectInterfaces/IndirectInterfacesModel.cpp:317:61: error: expected type-specifier before 'IndirectInterface'
     QSharedPointer<IndirectInterface> IndirectInterface(new IndirectInterface());

This is due to an ambiguity between variable name and class name.
This patch rename the variable to distinguish between both.

Signed-off-by: Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>