### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language : cpp
+addons:
+  apt:
+    packages:
+      - libqt5sql5-sqlite
+      - qt5-default
+      - qttools5-private-dev
+      - qttools5-dev-tools
+script:
+  - ./configure
+  - make -j2
+git:
+  depth: 1


### PR DESCRIPTION
This adds support for automatic build of latest commit with Travis CI to automatically check for broken builds

To enable this you need to set up a free travis account.

Sample output of a build can be found here https://travis-ci.org/olofk/kactus2dev
