### PR TITLE
Made namegroupeditor stretch the description box vertically as much as

### DIFF
--- a/common/widgets/nameGroupEditor/namegroupeditor.cpp
+++ b/common/widgets/nameGroupEditor/namegroupeditor.cpp
@@ -112,7 +112,7 @@ void NameGroupEditor::refresh()
 void NameGroupEditor::setupLayout()
 {
     // set the maximum height and width for this widget
-    setMaximumHeight(NameGroupEditor::MAX_EDITOR_HEIGHT);
+    //setMaximumHeight(NameGroupEditor::MAX_EDITOR_HEIGHT);
 
     // the layout manager for this widget
     QGridLayout* layout = new QGridLayout(this);
@@ -138,6 +138,7 @@ void NameGroupEditor::setupLayout()
 
     descriptionEdit_.setToolTip(tr("Set the description for the element"));
     layout->addWidget(&descriptionEdit_, 2, 1, 1, 1);
+    layout->setRowStretch(2,1);
 
     connect(&nameEdit_, SIGNAL(textEdited(const QString&)),
         this, SLOT(onNameChanged(const QString&)), Qt::UniqueConnection);

--- a/editors/ComponentEditor/memoryMaps/SingleAddressBlockEditor.cpp
+++ b/editors/ComponentEditor/memoryMaps/SingleAddressBlockEditor.cpp
@@ -272,7 +272,7 @@ void SingleAddressBlockEditor::setupLayout()
         this, SLOT(onVolatileSelected(QString const&)), Qt::UniqueConnection);
 
     QHBoxLayout* topOfPageLayout = new QHBoxLayout();
-    topOfPageLayout->addWidget(&nameEditor_, 0, Qt::AlignTop);
+    topOfPageLayout->addWidget(&nameEditor_, 0);
     topOfPageLayout->addWidget(addressBlockDefinitionGroup, 0);
 
     QWidget* topOfPageWidget = new QWidget();

--- a/editors/ComponentEditor/memoryMaps/SingleFieldEditor.cpp
+++ b/editors/ComponentEditor/memoryMaps/SingleFieldEditor.cpp
@@ -592,13 +592,15 @@ void SingleFieldEditor::setupLayout()
     fieldConstraintLayout->addRow(tr("Write constraint minimum, f(x):"), writeConstraintMinLimit_);
     fieldConstraintLayout->addRow(tr("Write constraint maximum, f(x):"), writeConstraintMaxLimit_);
 
-    QVBoxLayout* topLeftOfPageLayout = new QVBoxLayout();
-    topLeftOfPageLayout->addWidget(&nameEditor_, 0,Qt::AlignTop);
-    topLeftOfPageLayout->addWidget(fieldDefinitionGroup);
+
+    QVBoxLayout* topRightOfPageLayout = new QVBoxLayout();
+    topRightOfPageLayout->addWidget(fieldConstraintGroup, 0 ,Qt::AlignTop);
+    topRightOfPageLayout->addWidget(fieldDefinitionGroup);
 
     QHBoxLayout* topOfPageLayout = new QHBoxLayout();
-    topOfPageLayout->addLayout(topLeftOfPageLayout, 0);
-    topOfPageLayout->addWidget(fieldConstraintGroup, 0);
+    topOfPageLayout->addWidget(&nameEditor_, 0);
+    topOfPageLayout->addLayout(topRightOfPageLayout, 0);
+
 
     QWidget* topOfPageWidget = new QWidget();
     topOfPageWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/editors/ComponentEditor/memoryMaps/SingleMemoryMapEditor.cpp
+++ b/editors/ComponentEditor/memoryMaps/SingleMemoryMapEditor.cpp
@@ -154,7 +154,7 @@ void SingleMemoryMapEditor::setupLayout()
         this, SLOT(onRemapStateSelected(QString const&)), Qt::UniqueConnection);
 
     QHBoxLayout* topOfPageLayout = new QHBoxLayout();
-    topOfPageLayout->addWidget(&nameEditor_, 0, Qt::AlignTop);
+    topOfPageLayout->addWidget(&nameEditor_, 0);
     topOfPageLayout->addWidget(memoryMapDefinitionGroup, 0);
 
     QWidget* topOfPageWidget = new QWidget();

--- a/editors/ComponentEditor/memoryMaps/SingleRegisterEditor.cpp
+++ b/editors/ComponentEditor/memoryMaps/SingleRegisterEditor.cpp
@@ -128,7 +128,7 @@ void SingleRegisterEditor::setupLayout()
         this, SLOT(onAccessSelected(QString const&)), Qt::UniqueConnection);
 
     QHBoxLayout* topOfPageLayout = new QHBoxLayout();
-    topOfPageLayout->addWidget(&nameEditor_, 0, Qt::AlignTop);
+    topOfPageLayout->addWidget(&nameEditor_, 0);
     topOfPageLayout->addWidget(registerDefinitionGroup, 0);
 
     QWidget* topOfPageWidget = new QWidget();


### PR DESCRIPTION
This Feature allows the description box to expand to fill what was previously empty whitespace in the AddressBlock, Register, and Field  memory map editors