### PR TITLE
Address Overlap is Only Checked if Both Items Are Present

### DIFF
--- a/IPXACTmodels/Component/validators/AddressBlockValidator.cpp
+++ b/IPXACTmodels/Component/validators/AddressBlockValidator.cpp
@@ -220,7 +220,9 @@ bool AddressBlockValidator::hasValidRegisterData(QSharedPointer<AddressBlock> ad
                             return false;
                         }
 
-                        reservedArea.addArea(targetRegister->name(), registerBegin, registerEnd);
+                        if(targetRegister->getIsPresent().isEmpty() or expressionParser_->parseExpression(targetRegister->getIsPresent()).toInt()){
+                          reservedArea.addArea(targetRegister->name(), registerBegin, registerEnd);
+                        }
                     }
 
                     registerNames.append(targetRegister->name());

--- a/IPXACTmodels/Component/validators/AddressBlockValidator.cpp
+++ b/IPXACTmodels/Component/validators/AddressBlockValidator.cpp
@@ -526,7 +526,7 @@ void AddressBlockValidator::findErrorsInRegisterData(QVector<QString>& errors,
                     errors.append(QObject::tr("Register %1 size must not be greater than the containing "
                         "addressBlock %2 width.").arg(targetRegister->name()).arg(addressBlock->name()));
                 }
-                
+
                 if (!hasValidVolatileForRegister(addressBlock, targetRegister))
                 {
                     errors.append(QObject::tr("Volatile value cannot be set to false for addressBlock %1 "
@@ -563,9 +563,11 @@ void AddressBlockValidator::findErrorsInRegisterData(QVector<QString>& errors,
                     qint64 registerBegin = expressionParser_->parseExpression(targetRegister->getAddressOffset()).
                         toLongLong();
 
-                     qint64 registerEnd = registerBegin + registerSize - 1;
+                    qint64 registerEnd = registerBegin + registerSize - 1;
 
-                    reservedArea.addArea(targetRegister->name(), registerBegin, registerEnd);
+                    if(targetRegister->getIsPresent().isEmpty() or expressionParser_->parseExpression(targetRegister->getIsPresent()).toInt()){
+                      reservedArea.addArea(targetRegister->name(), registerBegin, registerEnd);
+                    }
 
                     if ( registerBegin < 0 || registerBegin + registerSize > addressBlockRange)
                     {

--- a/IPXACTmodels/Component/validators/MemoryMapBaseValidator.cpp
+++ b/IPXACTmodels/Component/validators/MemoryMapBaseValidator.cpp
@@ -144,13 +144,13 @@ bool MemoryMapBaseValidator::addressBlockWidthIsMultiplicationOfAUB(QString cons
 {
     bool aubToIntOk = true;
     bool widthToIntOk = true;
-    
+
     int addressUnitBitsInt = 8;
     if (!addressUnitBits.isEmpty())
     {
         addressUnitBitsInt = expressionParser_->parseExpression(addressUnitBits).toInt(&aubToIntOk);
     }
-    
+
     int addressBlockWidth = expressionParser_->parseExpression(addressBlock->getWidth()).toInt(&widthToIntOk);
 
     return aubToIntOk && widthToIntOk && addressUnitBitsInt != 0 && addressBlockWidth % addressUnitBitsInt == 0;
@@ -185,18 +185,23 @@ bool MemoryMapBaseValidator::addressBlockOverlaps(QSharedPointer<AddressBlock> a
 bool MemoryMapBaseValidator::twoAddressBlocksOverlap(QSharedPointer<AddressBlock> addressBlock,
     QSharedPointer<AddressBlock> comparedBlock) const
 {
-    int blockBegin = expressionParser_->parseExpression(addressBlock->getBaseAddress()).toInt();
-    int blockEnd = blockBegin + expressionParser_->parseExpression(addressBlock->getRange()).toInt() - 1;
+    int blockBegin    = expressionParser_->parseExpression(addressBlock->getBaseAddress()).toInt();
+    int blockEnd      = blockBegin + expressionParser_->parseExpression(addressBlock->getRange()).toInt() - 1;
+    bool blockPresent = addressBlock->getIsPresent().isEmpty() || expressionParser_->parseExpression(addressBlock->getIsPresent()).toInt();
 
-    int compareBegin = expressionParser_->parseExpression(comparedBlock->getBaseAddress()).toInt();
-    int compareEnd = compareBegin + expressionParser_->parseExpression(comparedBlock->getRange()).toInt() - 1;
 
-    if (((blockBegin >= compareBegin && blockBegin <= compareEnd) ||
-        (blockEnd >= compareBegin && blockEnd <= compareEnd)) ||
-        ((compareBegin >= blockBegin && compareBegin <= blockEnd) ||
-        (compareEnd >= blockBegin && compareEnd <= blockEnd)))
-    {
-        return true;
+    int compareBegin    = expressionParser_->parseExpression(comparedBlock->getBaseAddress()).toInt();
+    int compareEnd      = compareBegin + expressionParser_->parseExpression(comparedBlock->getRange()).toInt() - 1;
+    bool comparedPresent = comparedBlock->getIsPresent().isEmpty() || expressionParser_->parseExpression(comparedBlock->getIsPresent()).toInt();
+
+    if (blockPresent && comparedPresent) {
+      if (((blockBegin >= compareBegin && blockBegin <= compareEnd) ||
+          (blockEnd >= compareBegin && blockEnd <= compareEnd)) ||
+          ((compareBegin >= blockBegin && compareBegin <= blockEnd) ||
+          (compareEnd >= blockBegin && compareEnd <= blockEnd)))
+      {
+          return true;
+      }
     }
 
     return false;

--- a/IPXACTmodels/Component/validators/RegisterValidator.cpp
+++ b/IPXACTmodels/Component/validators/RegisterValidator.cpp
@@ -129,7 +129,7 @@ bool RegisterValidator::hasValidDimension(QSharedPointer<Register> selectedRegis
 //-----------------------------------------------------------------------------
 bool RegisterValidator::hasValidAddressOffset(QSharedPointer<Register> selectedRegister) const
 {
-    bool changeOk = true; 
+    bool changeOk = true;
     bool expressionValid = false;
 
     QString solvedValue =
@@ -146,7 +146,7 @@ bool RegisterValidator::hasValidSize(QSharedPointer<Register> selectedRegister) 
 {
     bool changeOk = true;
     bool expressionValid = false;
- 
+
     QString solvedValue = expressionParser_->parseExpression(selectedRegister->getSize(), &expressionValid);
     quint64 sizeInt = solvedValue.toULongLong(&changeOk);
 
@@ -191,7 +191,9 @@ bool RegisterValidator::hasValidFields(QSharedPointer<RegisterDefinition> select
                 return false;
             }
 
-            reservedArea.addArea(field->name(), rangeBegin, rangeEnd);
+            if(field->getIsPresent().isEmpty() || expressionParser_->parseExpression(field->getIsPresent()).toInt()){
+              reservedArea.addArea(field->name(), rangeBegin, rangeEnd);
+            }
 
             if (!field->getTypeIdentifier().isEmpty() && fieldTypeIdentifiers.contains(field->getTypeIdentifier()))
             {
@@ -255,7 +257,7 @@ bool RegisterValidator::hasValidAlternateGroups(QSharedPointer<AlternateRegister
 {
     QRegularExpression whiteSpaceExpression;
     whiteSpaceExpression.setPattern(QStringLiteral("^\\s*$"));
-        
+
     QStringList alternateGroups;
     bool alternateGroupsOk = false;
     foreach (QString group, *selectedRegister->getAlternateGroups())
@@ -333,7 +335,7 @@ bool RegisterValidator::fieldsHaveSimilarDefinitionGroups(QSharedPointer<Field> 
     {
         foreach (QSharedPointer<EnumeratedValue> comparedEnumeratedValue, *comparedField->getEnumeratedValues())
         {
-            if (enumeratedValue->name() == comparedEnumeratedValue->name() && 
+            if (enumeratedValue->name() == comparedEnumeratedValue->name() &&
                 enumeratedValue->displayName() == comparedEnumeratedValue->displayName() &&
                 enumeratedValue->description() == comparedEnumeratedValue->description() &&
                 enumeratedValue->getValue() == comparedEnumeratedValue->getValue() &&

--- a/IPXACTmodels/Component/validators/RegisterValidator.cpp
+++ b/IPXACTmodels/Component/validators/RegisterValidator.cpp
@@ -497,7 +497,9 @@ void RegisterValidator::findErrorsInFields(QVector<QString>& errors,
                     arg(selectedRegister->name()));
             }
 
-            reservedArea.addArea(field->name(), rangeBegin, rangeEnd);
+            if(field->getIsPresent().isEmpty() || expressionParser_->parseExpression(field->getIsPresent()).toInt()){
+              reservedArea.addArea(field->name(), rangeBegin, rangeEnd);
+            }
 
             if (!field->getTypeIdentifier().isEmpty() && fieldTypeIdentifiers.contains(field->getTypeIdentifier()))
             {


### PR DESCRIPTION
According IEEE 1685-2014     Section C.10.2  (Paraphrased)

When nonpresent, the enclosing element and all of its
descendants shall be treated as if they do not exist in the file.