### PR TITLE
Fixes segmentation fault on strlen.

### DIFF
--- a/mainwindow/main.cpp
+++ b/mainwindow/main.cpp
@@ -48,7 +48,7 @@ namespace
     //-----------------------------------------------------------------------------
     // Function: createApplication()
     //-----------------------------------------------------------------------------
-    QCoreApplication* createApplication(int argc, char* argv[])
+    QCoreApplication* createApplication(int &argc, char* argv[])
     {
         QCoreApplication* application = 0; 
         if (startGui(argc))


### PR DESCRIPTION
```
#0  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:120
#1  0x00007ffff6a5fbfb in QCoreApplication::arguments() () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#2  0x00007ffff2066dc1 in ?? () from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5
#3  0x00007ffff20672a9 in QXcbIntegration::wmClass() const () from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5
#4  0x00007ffff207cdc8 in QXcbWindow::create() () from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5
#5  0x00007ffff206830e in QXcbIntegration::createPlatformWindow(QWindow*) const ()
   from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5
#6  0x00007ffff6e9c3a5 in QWindowPrivate::create(bool, unsigned long long) ()
   from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5
#7  0x00007ffff748ebad in QWidgetPrivate::create_sys(unsigned long long, bool, bool) ()
   from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#8  0x00007ffff748f1ed in QWidget::create(unsigned long long, bool, bool) ()
   from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#9  0x00007ffff749c233 in QWidget::setVisible(bool) () from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#10 0x00007ffff76499ca in QDialog::setVisible(bool) () from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#11 0x00007ffff7649061 in QDialog::exec() () from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#12 0x0000555555a28ec0 in MainWindow::changeProtection (this=0x7fffffffd9c0, locked=false)
    at mainwindow/mainwindow.cpp:3347
#13 0x0000555555f06d69 in MainWindow::qt_static_metacall (_o=0x7fffffffd9c0, _c=QMetaObject::InvokeMetaMethod, 
_id=45, _a=0x7fffffffce00) at GeneratedFiles/moc_mainwindow.cpp:463
```

According to http://doc.qt.io/qt-5/qapplication.html#QApplication argc must live for the entire lifetime of the QApplication.
