### PR TITLE
IPXACt Models Now Support Reading and Writing Multiple reset values.

### DIFF
--- a/IPXACTmodels/Component/Field.cpp
+++ b/IPXACTmodels/Component/Field.cpp
@@ -24,9 +24,7 @@ Extendable(),
 id_(),
 isPresent_(),
 bitOffset_(),
-resetTypeReference_(),
-resetValue_(),
-resetMask_(),
+resets_(new QList<QSharedPointer<FieldReset> >()),
 typeIdentifier_(),
 bitWidth_(),
 volatile_(),
@@ -54,9 +52,7 @@ Extendable(other),
 id_(other.id_),
 isPresent_(other.isPresent_),
 bitOffset_(other.bitOffset_),
-resetTypeReference_(other.resetTypeReference_),
-resetValue_(other.resetValue_),
-resetMask_(other.resetMask_),
+resets_(new QList<QSharedPointer<FieldReset> >()),
 typeIdentifier_(other.typeIdentifier_),
 bitWidth_(other.bitWidth_),
 volatile_(other.volatile_),
@@ -75,6 +71,7 @@ parameters_(new QList<QSharedPointer<Parameter> > ())
     copyEnumeratedValues(other);
     copyParameters(other);
     copyWriteValueConstraint(other);
+    copyResets(other);
 }
 
 //-----------------------------------------------------------------------------
@@ -89,9 +86,6 @@ Field& Field::operator=( const Field& other )
         id_ = other.id_;
         isPresent_ = other.isPresent_;
         bitOffset_ = other.bitOffset_;
-        resetTypeReference_ = other.resetTypeReference_;
-        resetValue_ = other.resetValue_;
-        resetMask_ = other.resetMask_;
         typeIdentifier_ = other.typeIdentifier_;
         bitWidth_ = other.bitWidth_;
         volatile_ = other.volatile_;
@@ -110,6 +104,8 @@ Field& Field::operator=( const Field& other )
         copyWriteValueConstraint(other);
         parameters_->clear();
         copyParameters(other);
+        resets_->clear();
+        copyResets(other);
     }
 
     return *this;
@@ -120,6 +116,7 @@ Field& Field::operator=( const Field& other )
 //-----------------------------------------------------------------------------
 Field::~Field()
 {
+    resets_.clear();
     enumeratedValues_.clear();
     parameters_.clear();
     writeValueConstraint_.clear();
@@ -173,28 +170,53 @@ void Field::setBitOffset(QString const& newBitOffset)
     bitOffset_ = newBitOffset;
 }
 
+
+
+
 //-----------------------------------------------------------------------------
 // Function: Field::getResetTypeReference()
 //-----------------------------------------------------------------------------
 QString Field::getResetTypeReference() const
 {
-    return resetTypeReference_;
+  if(resets_->isEmpty()){
+    return QStringLiteral("");
+  }else{
+    return resets_->last()->resetTypeReference_;
+  }
 }
+//-----------------------------------------------------------------------------
+// Function: field::getResetValue()
+//-----------------------------------------------------------------------------
+QString Field::getResetValue() const
+{
+  if(resets_->isEmpty()){
+    return QStringLiteral("");
+  }else{
+    return resets_->last()->resetValue_;
+  }
+}
+//-----------------------------------------------------------------------------
+// Function: field::getResetMask()
+//-----------------------------------------------------------------------------
+QString Field::getResetMask() const
+{
+  if(resets_->isEmpty()){
+    return QStringLiteral("");
+  }else{
+    return resets_->last()->resetMask_;
+  }
+}
+
 
 //-----------------------------------------------------------------------------
 // Function: Field::setResetTypeReference()
 //-----------------------------------------------------------------------------
 void Field::setResetTypeReference(QString const& newResetTypeReference)
 {
-    resetTypeReference_ = newResetTypeReference;
-}
-
-//-----------------------------------------------------------------------------
-// Function: field::getResetValue()
-//-----------------------------------------------------------------------------
-QString Field::getResetValue() const
-{
-    return resetValue_;
+  if(resets_->isEmpty()){
+    resets_->append(QSharedPointer<FieldReset>(new FieldReset()));
+  }
+  resets_->last()->resetTypeReference_ = newResetTypeReference;
 }
 
 //-----------------------------------------------------------------------------
@@ -202,15 +224,10 @@ QString Field::getResetValue() const
 //-----------------------------------------------------------------------------
 void Field::setResetValue(QString const& newResetValue)
 {
-    resetValue_ = newResetValue;
-}
-
-//-----------------------------------------------------------------------------
-// Function: field::getResetMask()
-//-----------------------------------------------------------------------------
-QString Field::getResetMask() const
-{
-    return resetMask_;
+  if(resets_->isEmpty()){
+    resets_->append(QSharedPointer<FieldReset>(new FieldReset()));
+  }
+  resets_->last()->resetValue_ = newResetValue;
 }
 
 //-----------------------------------------------------------------------------
@@ -218,8 +235,30 @@ QString Field::getResetMask() const
 //-----------------------------------------------------------------------------
 void Field::setResetMask(QString const& newResetMask)
 {
-    resetMask_ = newResetMask;
+  if(resets_->isEmpty()){
+    resets_->append(QSharedPointer<FieldReset>(new FieldReset()));
+  }
+  resets_->last()->resetMask_ = newResetMask;
 }
+
+//-----------------------------------------------------------------------------
+// Function: Field::getResets()
+//-----------------------------------------------------------------------------
+QSharedPointer<QList<QSharedPointer<FieldReset> > > Field::getResets() const
+{
+    return resets_;
+}
+
+//-----------------------------------------------------------------------------
+// Function: Field::setResets()
+//-----------------------------------------------------------------------------
+void Field::setResets(QSharedPointer<QList<QSharedPointer<FieldReset> > > newResets)
+{
+    resets_->clear();
+    resets_ = newResets;
+}
+
+
 
 //-----------------------------------------------------------------------------
 // Function: Field::getTypeIdentifier()
@@ -503,4 +542,19 @@ void Field::copyWriteValueConstraint(const Field& other)
         writeValueConstraint_ =
             QSharedPointer<WriteValueConstraint>(new WriteValueConstraint(*other.writeValueConstraint_.data()));
     }
+}
+
+//-----------------------------------------------------------------------------
+// Function: Field::copyWriteValueConstraint()
+//-----------------------------------------------------------------------------
+void Field::copyResets(const Field& other)
+{
+  foreach (QSharedPointer<FieldReset> other_reset, *other.resets_)
+  {
+      if (other_reset)
+      {
+          QSharedPointer<FieldReset> copy = QSharedPointer<FieldReset>(new FieldReset(*other_reset.data()));
+          resets_->append(copy);
+      }
+  }
 }

--- a/IPXACTmodels/Component/Field.h
+++ b/IPXACTmodels/Component/Field.h
@@ -29,6 +29,20 @@ class Parameter;
 class EnumeratedValue;
 class WriteValueConstraint;
 
+
+//! Local structure Defining A Single Reset
+struct FieldReset {
+	//! Identifies the type of the reset being defined.
+	QString resetTypeReference_;
+	//! Contains the actual reset value.
+	QString resetValue_;
+	//! Defines which bits of the register field have a known reset value.
+	QString resetMask_;
+};
+
+
+
+
 //-----------------------------------------------------------------------------
 //! Describes the ipxact:field element.
 //-----------------------------------------------------------------------------
@@ -37,11 +51,12 @@ class IPXACTMODELS_EXPORT Field : public NameGroup, public Extendable
 
 public:
 
+
 	/*!
-	 *  The constructor.
-	 *
-	 *      @param [in] name    Name of the bit field.
-	 */
+	*  The constructor.
+	*
+	*      @param [in] name    Name of the bit field.
+	*/
 	Field(QString const& name = QString());
 
 	//! Copy constructor
@@ -52,355 +67,394 @@ public:
 
 	//! The destructor.
 	virtual ~Field();
-    
-    /*!
-     *  Get the id of the field.
-     *
-     *      @return The field's id.
-     */
-    QString getId() const;
 
-    /*!
-     *  Set the id for the field.
-     *
-     *      @param [in] newId   The id to set for the field.
-     *
-     */
-    void setId(QString const& newId);
 
-    /*!
-     *  Get the isPresent value of the field.
-     *
-     *       @return The is present value.
-     */
-    QString getIsPresent() const;
 
-    /*!
-     *  Set the is present value for the field.
-     *
-     *      @param [in] newIsPresent    The new is present value.
-     */
-    void setIsPresent(QString const& newIsPresent);
 
 	/*!
-     *  Get the bit offset.
-	 *
-	 *      @return Bit offset.
-	 */
-    QString getBitOffset() const;
-
-    /*!
-     *  Set the bit offset.
-     *
-     *      @param [in] newBitOffset    The new bit offset.
-     */
-    void setBitOffset(QString const& newBitOffset);
-
-    /*!
-     *  Get the reset type reference.
-     *
-     *      @return The name of the referenced reset type.
-     */
-    QString getResetTypeReference() const;
-
-    /*!
-     *  Set the reset type reference.
-     *
-     *      @param [in] newResetTypeReference   The name of the referenced reset type.
-     */
-    void setResetTypeReference(QString const& newResetTypeReference);
-
-    /*!
-     *  Get the reset value of this field.
-     *
-     *      @return The reset value associated with this field.
-     */
-    QString getResetValue() const;
-    
-    /*!
-     *  Set the reset value for this field.
-     *
-     *      @param [in] newResetValue   The new reset value.
-     */
-    void setResetValue(QString const& newResetValue);
-
-    /*!
-     *  Get the reset mask of this field.
-     *
-     *      @return The reset mask associated with this field.
-     */
-    QString getResetMask() const;
-
-    /*!
-     *  Set the reset mask for this field.
-     *
-     *      @param [in] newResetMask    The new reset mask.
-     */
-    void setResetMask(QString const& newResetMask);
-
-    /*!
-     *  Get the typeIdentifier.
-     *
-     *      @return The typeIdentifier.
-     */
-    QString getTypeIdentifier() const;
-
-    /*!
-     *  Set the typeIdentifier for the field.
-     *
-     *      @param [in] newTypeIdentifier   The new typeIdentifier.
-     */
-    void setTypeIdentifier(QString const& newTypeIdentifier);
-
-    /*!
-     *  Get the bit width.
-     *
-     *       @return Bit width.
-     */
-    QString getBitWidth() const;
-
-    /*!
-     *  Set the bit width for the field.
-     *
-     *      @param [in] newBitwidth     The new bit width.
-     */
-    void setBitWidth(QString const& newBitWidth);
-    
-	/*!
-     *  Get the volatile state of the field.
-	 *
-	 *      @return The volatile state.
-	 */
-    BooleanValue getVolatile() const;
-
-    /*!
-     *  Set the volatile value to unspecified.
-     */
-    void clearVolatile();
+	*  Get the id of the field.
+	*
+	*      @return The field's id.
+	*/
+	QString getId() const;
 
 	/*!
-     *  Set the volatile state for the field.
-	 *
-	 *      @param [in] volatileValue   The new volatile state to set.
-	 */
+	*  Set the id for the field.
+	*
+	*      @param [in] newId   The id to set for the field.
+	*
+	*/
+	void setId(QString const& newId);
+
+	/*!
+	*  Get the isPresent value of the field.
+	*
+	*       @return The is present value.
+	*/
+	QString getIsPresent() const;
+
+	/*!
+	*  Set the is present value for the field.
+	*
+	*      @param [in] newIsPresent    The new is present value.
+	*/
+	void setIsPresent(QString const& newIsPresent);
+
+	/*!
+	*  Get the bit offset.
+	*
+	*      @return Bit offset.
+	*/
+	QString getBitOffset() const;
+
+	/*!
+	*  Set the bit offset.
+	*
+	*      @param [in] newBitOffset    The new bit offset.
+	*/
+	void setBitOffset(QString const& newBitOffset);
+
+	/*!
+	*  Get the reset type reference for the final reset of this field.
+	*
+	*      @return The name of the referenced reset type.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.
+	*/
+	QString getResetTypeReference() const;
+
+	/*!
+	*  Set the reset type reference for the final reset of this field.
+	*
+	*      @param [in] newResetTypeReference   The name of the referenced reset type.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.  Otherwise it will create one.
+	*/
+	void setResetTypeReference(QString const& newResetTypeReference);
+
+	/*!
+	*  Get the reset value of the final reset in this field.
+	*
+	*      @return The reset value associated with this field.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.
+	*/
+	QString getResetValue() const;
+
+	/*!
+	*  Set the reset value for the final reset in this field.
+	*
+	*      @param [in] newResetValue   The new reset value.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.  Otherwise it will create one.
+	*/
+	void setResetValue(QString const& newResetValue);
+
+	/*!
+	*  Get the reset mask of the final reset in this field.
+	*
+	*      @return The reset mask associated with this field.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.
+	*/
+	QString getResetMask() const;
+
+	/*!
+	*  Set the reset mask for the final reset in this field.
+	*
+	*      @param [in] newResetMask    The new reset mask.
+	*      @note This method is left for backwards compatability with editors which expect a single reset value.
+	*            This method will only effect the final reset in the list if it exists.  Otherwise it will create one.
+	*/
+	void setResetMask(QString const& newResetMask);
+
+
+	/*!
+	*  Get a list of the reset for the field.
+	*
+	*      @return Pointer to a list containing the resets.
+	*/
+	QSharedPointer<QList<QSharedPointer<FieldReset> > > getResets() const;
+
+	/*!
+	*  Set the reset for the field.
+	*
+	*      @param [in] newResets   Pointer to a list containing the new resets.
+	*/
+	void setResets(QSharedPointer<QList<QSharedPointer<FieldReset> > > newResets);
+
+
+
+
+	/*!
+	*  Get the typeIdentifier.
+	*
+	*      @return The typeIdentifier.
+	*/
+	QString getTypeIdentifier() const;
+
+	/*!
+	*  Set the typeIdentifier for the field.
+	*
+	*      @param [in] newTypeIdentifier   The new typeIdentifier.
+	*/
+	void setTypeIdentifier(QString const& newTypeIdentifier);
+
+	/*!
+	*  Get the bit width.
+	*
+	*       @return Bit width.
+	*/
+	QString getBitWidth() const;
+
+	/*!
+	*  Set the bit width for the field.
+	*
+	*      @param [in] newBitwidth     The new bit width.
+	*/
+	void setBitWidth(QString const& newBitWidth);
+
+	/*!
+	*  Get the volatile state of the field.
+	*
+	*      @return The volatile state.
+	*/
+	BooleanValue getVolatile() const;
+
+	/*!
+	*  Set the volatile value to unspecified.
+	*/
+	void clearVolatile();
+
+	/*!
+	*  Set the volatile state for the field.
+	*
+	*      @param [in] volatileValue   The new volatile state to set.
+	*/
 	void setVolatile(bool volatileValue);
-    
+
 	/*!
-     *  Get the access type of the field.
-	 *
-	 *      @return The access type of the field.
-	 */
+	*  Get the access type of the field.
+	*
+	*      @return The access type of the field.
+	*/
 	AccessTypes::Access getAccess() const;
 
 	/*!
-     *  Set the access type for the field.
-	 *
-	 *      @param [in] access  The access type to set.
-	 */
+	*  Set the access type for the field.
+	*
+	*      @param [in] access  The access type to set.
+	*/
 	void setAccess(AccessTypes::Access access);
-    
-    /*!
-     *  Get the list of the enumeratedValues.
-     *
-     *      @return Pointer to a list containing the enumerated values.
-     */
-    QSharedPointer<QList<QSharedPointer<EnumeratedValue> > > getEnumeratedValues() const;
-
-    /*!
-     *  Set the enumerated values for the field.
-     *
-     *      @param [in] newEnumeratedValues     Pointer to a list containing the enumerated values.
-     */
-    void setEnumeratedValues(QSharedPointer<QList<QSharedPointer<EnumeratedValue> > > newEnumeratedValues);
 
 	/*!
-     *  Get the modified write value setting of the field.
-	 *
-	 *      @return The modified write value setting.
-	 */
+	*  Get the list of the enumeratedValues.
+	*
+	*      @return Pointer to a list containing the enumerated values.
+	*/
+	QSharedPointer<QList<QSharedPointer<EnumeratedValue> > > getEnumeratedValues() const;
+
+	/*!
+	*  Set the enumerated values for the field.
+	*
+	*      @param [in] newEnumeratedValues     Pointer to a list containing the enumerated values.
+	*/
+	void setEnumeratedValues(QSharedPointer<QList<QSharedPointer<EnumeratedValue> > > newEnumeratedValues);
+
+	/*!
+	*  Get the modified write value setting of the field.
+	*
+	*      @return The modified write value setting.
+	*/
 	General::ModifiedWrite getModifiedWrite() const;
 
 	/*!
-     *  Set the modified write value setting for the field.
-	 *
-	 *      @param [in] newModWriteValue    The value to set.
-	 *
-	 */
+	*  Set the modified write value setting for the field.
+	*
+	*      @param [in] newModWriteValue    The value to set.
+	*
+	*/
 	void setModifiedWrite(General::ModifiedWrite const& newModifiedWriteValue);
-    
-    /*!
-     *  Get the modify attribute of the modified write value.
-     *
-     *      @return The modify attribute of the modified write value.
-     */
-    QString getModifiedWriteModify() const;
-
-    /*!
-     *  Set the modify attribute of the modified write value.
-     *
-     *      @param [in] newModify   The new modified attribute.
-     */
-    void setModifiedWriteModify(QString const& newModify);
 
 	/*!
-     *  Get the write constraint of the field.
-	 *
-	 *      @return Pointer to the write constraint.
-	 */
+	*  Get the modify attribute of the modified write value.
+	*
+	*      @return The modify attribute of the modified write value.
+	*/
+	QString getModifiedWriteModify() const;
+
+	/*!
+	*  Set the modify attribute of the modified write value.
+	*
+	*      @param [in] newModify   The new modified attribute.
+	*/
+	void setModifiedWriteModify(QString const& newModify);
+
+	/*!
+	*  Get the write constraint of the field.
+	*
+	*      @return Pointer to the write constraint.
+	*/
 	QSharedPointer<WriteValueConstraint> getWriteConstraint() const;
 
-    /*!
-     *  Set the write value constraint.
-     *
-     *      @param [in] newWriteValueConstraint     Pointer to the new write value constraint.
-     */
-    void setWriteConstraint(QSharedPointer<WriteValueConstraint> newWriteValueConstraint);
-    
 	/*!
-     *  Get the read action setting of the field.
-	 *
-	 *      @return The read action setting.
-	 */
+	*  Set the write value constraint.
+	*
+	*      @param [in] newWriteValueConstraint     Pointer to the new write value constraint.
+	*/
+	void setWriteConstraint(QSharedPointer<WriteValueConstraint> newWriteValueConstraint);
+
+	/*!
+	*  Get the read action setting of the field.
+	*
+	*      @return The read action setting.
+	*/
 	General::ReadAction getReadAction() const;
 
 	/*!
-     *  Set the read action setting for the field.
-	 *
-	 *      @param [in] readAction  The new read actionvalue.
-	 */
+	*  Set the read action setting for the field.
+	*
+	*      @param [in] readAction  The new read actionvalue.
+	*/
 	void setReadAction(General::ReadAction const& readAction);
 
-    /*!
-     *  Get the read action modify attribute.
-     *
-     *      @return The read action modify attribute.
-     */
-    QString getReadActionModify() const;
-
-    /*!
-     *  Set the read action modify attribute.
-     *
-     *      @param [in] newModify   The new modify attribute.
-     */
-    void setReadActionModify(QString const& newModify);
-    
 	/*!
-     *  Get the testable setting of the field.
-	 *
-	 *      @return The testable setting.
-	 */
-    BooleanValue getTestable() const;
+	*  Get the read action modify attribute.
+	*
+	*      @return The read action modify attribute.
+	*/
+	QString getReadActionModify() const;
 
 	/*!
-     *  Set the testable setting for the field.
-	 *
-	 *      @param [in] newTestable     The new testable value.
-	 */
-    void setTestable(bool newTestable);
-
-    /*!
-     *  Clear the testable value of the field.
-     */
-    void clearTestable();
+	*  Set the read action modify attribute.
+	*
+	*      @param [in] newModify   The new modify attribute.
+	*/
+	void setReadActionModify(QString const& newModify);
 
 	/*!
-     *  Get the test constraint setting of the field.
-	 *
-	 *      @return The test constraint of the field.
-	 */
+	*  Get the testable setting of the field.
+	*
+	*      @return The testable setting.
+	*/
+	BooleanValue getTestable() const;
+
+	/*!
+	*  Set the testable setting for the field.
+	*
+	*      @param [in] newTestable     The new testable value.
+	*/
+	void setTestable(bool newTestable);
+
+	/*!
+	*  Clear the testable value of the field.
+	*/
+	void clearTestable();
+
+	/*!
+	*  Get the test constraint setting of the field.
+	*
+	*      @return The test constraint of the field.
+	*/
 	General::TestConstraint getTestConstraint() const;
 
 	/*!
-     *  Set the test constraint for the field.
-	 *
-	 *      @param [in] testContraint   The new test constraint.
-	 */
+	*  Set the test constraint for the field.
+	*
+	*      @param [in] testContraint   The new test constraint.
+	*/
 	void setTestConstraint(General::TestConstraint const& newTestContraint);
 
-    /*!
-     *  Get the reserved value.
-     *
-     *      @return The reserved value.
-     */
-    QString getReserved() const;
+	/*!
+	*  Get the reserved value.
+	*
+	*      @return The reserved value.
+	*/
+	QString getReserved() const;
 
-    /*!
-     *  Set the reserved value.
-     *
-     *      @param [in] newReserved     The new reserved value.
-     */
-    void setReserved(QString const& newReserved);
+	/*!
+	*  Set the reserved value.
+	*
+	*      @param [in] newReserved     The new reserved value.
+	*/
+	void setReserved(QString const& newReserved);
 
-    /*!
-     *  Get a list of the parameters for the field.
-     *
-     *      @return Pointer to a list containing the parameters.
-     */
-    QSharedPointer<QList<QSharedPointer<Parameter> > > getParameters() const;
+	/*!
+	*  Get a list of the parameters for the field.
+	*
+	*      @return Pointer to a list containing the parameters.
+	*/
+	QSharedPointer<QList<QSharedPointer<Parameter> > > getParameters() const;
 
-    /*!
-     *  Set the parameters for the field.
-     *
-     *      @param [in] newParameters   Pointer to a list containing the new parameters.
-     */
-    void setParameters(QSharedPointer<QList<QSharedPointer<Parameter> > > newParameters);
-    
+	/*!
+	*  Set the parameters for the field.
+	*
+	*      @param [in] newParameters   Pointer to a list containing the new parameters.
+	*/
+	void setParameters(QSharedPointer<QList<QSharedPointer<Parameter> > > newParameters);
+
+
+
+
 private:
 
-    /*!
-     *  Copy the enumerated values.
-     *
-     *      @param [in] other   The copied field.
-     */
-    void copyEnumeratedValues(const Field& other);
 
-    /*!
-     *  Copy the parameters.
-     *
-     *      @param [in] other   The copied field.
-     */
-    void copyParameters(const Field& other);
+	/*!
+	*  Copy the resets values.
+	*
+	*      @param [in] other   The copied field.
+	*/
+	void copyResets(const Field& other);
 
-    /*!
-     *  Copy the write value constraint.
-     *
-     *      @param [in] other   The copied field.
-     */
-    void copyWriteValueConstraint(const Field& other);
+	/*!
+	*  Copy the enumerated values.
+	*
+	*      @param [in] other   The copied field.
+	*/
+	void copyEnumeratedValues(const Field& other);
 
-    //-----------------------------------------------------------------------------
-    // Data.
-    //-----------------------------------------------------------------------------
+	/*!
+	*  Copy the parameters.
+	*
+	*      @param [in] other   The copied field.
+	*/
+	void copyParameters(const Field& other);
+
+	/*!
+	*  Copy the write value constraint.
+	*
+	*      @param [in] other   The copied field.
+	*/
+	void copyWriteValueConstraint(const Field& other);
+
+	//-----------------------------------------------------------------------------
+	// Data.
+	//-----------------------------------------------------------------------------
 
 	//! A unique id.
 	QString id_;
 
-    //! The presence of the field.
-    QString isPresent_;
+	//! The presence of the field.
+	QString isPresent_;
 
 	//! Describes the offset where this bit field starts.
-    QString bitOffset_;
+	QString bitOffset_;
 
-    //! Identifies the type of the reset being defined.
-    QString resetTypeReference_;
 
-    //! Contains the actual reset value.
-    QString resetValue_;
+	QSharedPointer<QList<QSharedPointer<FieldReset> > > resets_;
 
-    //! Defines which bits of the register field have a known reset value.
-    QString resetMask_;
 
 	// Field elements with the same identifier contain the same information for the field definition group.
 	QString typeIdentifier_;
 
 	//! Width of the field.
-    QString bitWidth_;
+	QString bitWidth_;
 
-    //! Contains the volatile value for the field.
-    BooleanValue volatile_;
+	//! Contains the volatile value for the field.
+	BooleanValue volatile_;
 
-    //! Contains the access type of the field.
-    AccessTypes::Access access_;
+	//! Contains the access type of the field.
+	AccessTypes::Access access_;
 
 	//! Pointer to a list containing the enumerated values.
 	QSharedPointer<QList<QSharedPointer<EnumeratedValue> > > enumeratedValues_;
@@ -408,29 +462,29 @@ private:
 	//! Contains the modified write setting for the field.
 	General::ModifiedWrite modifiedWrite_;
 
-    //! User defined value for a modify modified write.
-    QString modifiedWriteModify_;
+	//! User defined value for a modify modified write.
+	QString modifiedWriteModify_;
 
-    //! Pointer to the write value constraint.
-    QSharedPointer<WriteValueConstraint> writeValueConstraint_;
+	//! Pointer to the write value constraint.
+	QSharedPointer<WriteValueConstraint> writeValueConstraint_;
 
 	//! Contains the read action setting for the field.
 	General::ReadAction readAction_;
 
-    //! User defined additional information for a modify read action.
-    QString readActionModify_;
+	//! User defined additional information for a modify read action.
+	QString readActionModify_;
 
 	//! Contains the testable setting for the field.
-    BooleanValue testable_;
+	BooleanValue testable_;
 
 	//! Contains the test constraint setting for the field.
 	General::TestConstraint testConstraint_;
 
-    //! Indicates whether this field is reserved or not.
-    QString reserved_;
+	//! Indicates whether this field is reserved or not.
+	QString reserved_;
 
 	//! Contains the parameters.
-    QSharedPointer<QList<QSharedPointer<Parameter> > > parameters_;
+	QSharedPointer<QList<QSharedPointer<Parameter> > > parameters_;
 };
 
 Q_DECLARE_METATYPE(QSharedPointer<Field>);

--- a/IPXACTmodels/Component/FieldReader.h
+++ b/IPXACTmodels/Component/FieldReader.h
@@ -20,6 +20,7 @@
 #include <QDomNode>
 
 class Field;
+struct FieldReset;
 
 //-----------------------------------------------------------------------------
 //! Reader class for IP-XACT field element.
@@ -89,31 +90,31 @@ private:
      *      @param [in] fieldElement    XML description of the field.
      *      @param [in] newField        The new field item.
      */
-    void parseReset(QDomElement const& fieldElement, QSharedPointer<Field> newField) const;
+    void parseResets(QDomElement const& fieldElement, QSharedPointer<Field> newField) const;
 
     /*!
      *  Reads the reset type reference.
      *
      *      @param [in] resetElement    XML description of the reset.
-     *      @param [in] newField        The new field item.
+     *      @param [in] fldReset        The Reset Structure to parse into.
      */
-    void parseResetTypeRef(QDomElement const& resetElement, QSharedPointer<Field> newField) const;
+    void parseResetTypeRef(QDomElement const& resetElement, QSharedPointer<FieldReset> fldReset) const;
 
     /*!
      *  Reads the reset value.
      *
      *      @param [in] resetElement    XML description of the reset.
-     *      @param [in] newField        The new field item.
+     *      @param [in] fldReset        The Reset Structure to parse into.
      */
-    void parseResetValue(QDomElement const& resetElement, QSharedPointer<Field> newField) const;
+    void parseResetValue(QDomElement const& resetElement, QSharedPointer<FieldReset> fldReset) const;
 
     /*!
      *  Reads the reset mask.
      *
      *      @param [in] resetElement    XML description of the reset.
-     *      @param [in] newField        The new field item.
+     *      @param [in] fldReset        The Reset Structure to parse into.
      */
-    void parseResetMask(QDomElement const& resetElement, QSharedPointer<Field> newField) const;
+    void parseResetMask(QDomElement const& resetElement, QSharedPointer<FieldReset> fldReset) const;
 
     /*!
      *  Reads the type identifier.

--- a/IPXACTmodels/Component/FieldWriter.cpp
+++ b/IPXACTmodels/Component/FieldWriter.cpp
@@ -47,7 +47,7 @@ void FieldWriter::writeField(QXmlStreamWriter& writer, QSharedPointer<Field> fie
 
     writer.writeTextElement(QStringLiteral("ipxact:bitOffset"), field->getBitOffset());
 
-    writeReset(writer, field);
+    writeResets(writer, field);
 
     writeTypeIdentifier(writer, field);
 
@@ -97,32 +97,37 @@ void FieldWriter::writeNameGroup(QXmlStreamWriter& writer, QSharedPointer<Field>
 }
 
 //-----------------------------------------------------------------------------
-// Function: FieldWriter::writeReset()
+// Function: FieldWriter::writeResets()
 //-----------------------------------------------------------------------------
-void FieldWriter::writeReset(QXmlStreamWriter& writer, QSharedPointer<Field> field) const
+void FieldWriter::writeResets(QXmlStreamWriter& writer, QSharedPointer<Field> field) const
 {
-    if (!field->getResetTypeReference().isEmpty() || !field->getResetValue().isEmpty() ||
-        !field->getResetMask().isEmpty())
-    {
-        writer.writeStartElement(QStringLiteral("ipxact:resets"));
 
-        writer.writeStartElement(QStringLiteral("ipxact:reset"));
+    if(!field->getResets()->isEmpty()) {
+      writer.writeStartElement(QStringLiteral("ipxact:resets"));
 
-        if (!field->getResetTypeReference().isEmpty())
-        {
-            writer.writeAttribute(QStringLiteral("resetTypeRef"), field->getResetTypeReference());
-        }
+      foreach (QSharedPointer<FieldReset> reset, *(field->getResets()))
+      {
+          if (reset)
+          {
+            writer.writeStartElement(QStringLiteral("ipxact:reset"));
 
-        writer.writeTextElement(QStringLiteral("ipxact:value"), field->getResetValue());
+            if (!reset->resetTypeReference_.isEmpty())
+            {
+                writer.writeAttribute(QStringLiteral("resetTypeRef"), reset->resetTypeReference_);
+            }
 
-        if (!field->getResetMask().isEmpty())
-        {
-            writer.writeTextElement(QStringLiteral("ipxact:mask"), field->getResetMask());
-        }
+            writer.writeTextElement(QStringLiteral("ipxact:value"), reset->resetValue_);
 
-        writer.writeEndElement(); // ipxact:reset
+            if (!reset->resetMask_.isEmpty())
+            {
+                writer.writeTextElement(QStringLiteral("ipxact:mask"), reset->resetMask_);
+            }
 
-        writer.writeEndElement(); // ipxact:resets
+            writer.writeEndElement(); // ipxact:reset
+          }
+      }
+
+      writer.writeEndElement(); // ipxact:resets
     }
 }
 

--- a/IPXACTmodels/Component/FieldWriter.h
+++ b/IPXACTmodels/Component/FieldWriter.h
@@ -74,7 +74,7 @@ private:
      *      @param [in] writer  Used XML writer.
      *      @param [in] field   The selected field item.
      */
-    void writeReset(QXmlStreamWriter& writer, QSharedPointer<Field> field) const;
+    void writeResets(QXmlStreamWriter& writer, QSharedPointer<Field> field) const;
 
     /*!
      *  Write the type identifier.

--- a/IPXACTmodels/Component/validators/FieldValidator.cpp
+++ b/IPXACTmodels/Component/validators/FieldValidator.cpp
@@ -116,6 +116,7 @@ bool FieldValidator::hasValidBitOffset(QSharedPointer<Field> field) const
 
 //-----------------------------------------------------------------------------
 // Function: FieldValidator::hasValidResetValue()
+//TODO Validate All Resets (Currently Only Validates the final reset)
 //-----------------------------------------------------------------------------
 bool FieldValidator::hasValidResetValue(QSharedPointer<Field> field) const
 {
@@ -133,6 +134,7 @@ bool FieldValidator::hasValidResetValue(QSharedPointer<Field> field) const
 
 //-----------------------------------------------------------------------------
 // Function: FieldValidator::hasValidResetMask()
+//TODO Validate All Resets (Currently Only Validates the final reset)
 //-----------------------------------------------------------------------------
 bool FieldValidator::hasValidResetMask(QSharedPointer<Field> field) const
 {
@@ -209,7 +211,7 @@ bool FieldValidator::hasValidBitWidth(QSharedPointer<Field> field) const
     {
         return true;
     }
-    
+
     return false;
 }
 
@@ -565,7 +567,7 @@ void FieldValidator::findErrorsInAccess(QVector<QString>& errors, QSharedPointer
 bool FieldValidator::isBitExpressionValid(QString const& expression) const
 {
     QString solvedValue = expressionParser_->parseExpression(expression);
-    
+
     QRegularExpression bitExpression(QStringLiteral("^([0-9]+|[1-9]+[0-9]*'([bB][01_]+|[hH][0-9a-fA-F_]+))$"));
     return bitExpression.match(expression).hasMatch() || bitExpression.match(solvedValue).hasMatch();
 }


### PR DESCRIPTION
Editors are unaware of multiple resets, and will continue to act as iff only the last reset in the list exists.

fixes bug 13