### PR TITLE
Fixed issue with vendor extensions being deleted

### DIFF
--- a/IPXACTmodels/common/GenericVendorExtension.cpp
+++ b/IPXACTmodels/common/GenericVendorExtension.cpp
@@ -14,7 +14,7 @@
 #include <QDomNode>
 #include <QObject>
 
-const QString DESCRIPTION = "Description";
+const QString DESCRIPTION = QStringLiteral("Description");
 
 //-----------------------------------------------------------------------------
 // Function: GenericVendorExtension::GenericVendorExtension()
@@ -34,13 +34,15 @@ GenericVendorExtension::GenericVendorExtension(QDomNode const& extensionNode):
     }
 
     QDomNodeList childNodes = extensionNode.childNodes();
-    value_ = extensionNode.firstChild().nodeValue();
-
     const int childCount = childNodes.count();
-    for (int i = 1; i < childCount; ++i)
+    for (int i = 0; i < childCount; ++i)
     {
         QDomNode childNode = childNodes.at(i);
-        children_.append(GenericVendorExtension(childNode));
+        if(childNode.isText()){
+          value_.append(childNode.nodeValue());
+        } else{
+          children_.append(GenericVendorExtension(childNode));
+        }
     }
 }
 
@@ -81,7 +83,7 @@ QString GenericVendorExtension::type() const
 //-----------------------------------------------------------------------------
 void GenericVendorExtension::write(QXmlStreamWriter& writer) const
 {
-    writeNode(*this, writer);    
+    writeNode(*this, writer);
 }
 
 //-----------------------------------------------------------------------------
@@ -121,7 +123,7 @@ void GenericVendorExtension::setValue(QString const& value)
 //-----------------------------------------------------------------------------
 QString GenericVendorExtension::attributeValue(QString const& attributeName) const
 {
-    auto target = std::find_if(attributes_.cbegin(), attributes_.cend(), 
+    auto target = std::find_if(attributes_.cbegin(), attributes_.cend(),
         [attributeName](QPair<QString, QString> const& attribute) {return attribute.first == attributeName;});
 
     if (target == attributes_.cend())
@@ -163,7 +165,7 @@ QString GenericVendorExtension::getDescription() const
         }
     }
 
-    return "";
+    return QString();
 }
 
 //-----------------------------------------------------------------------------
@@ -220,7 +222,7 @@ void GenericVendorExtension::writeNode(GenericVendorExtension const& node, QXmlS
 void GenericVendorExtension::writeAttributes(GenericVendorExtension const& node, QXmlStreamWriter& writer) const
 {
     for (auto attribute : node.attributes_)
-    {      
+    {
         writer.writeAttribute(attribute.first, attribute.second);
     }
 }
@@ -232,6 +234,6 @@ void GenericVendorExtension::writeChildNodes(GenericVendorExtension const& node,
 {
     for (auto child : node.children_)
     {
-        writeNode(child, writer);                
+        writeNode(child, writer);
     }
 }


### PR DESCRIPTION
I needed a quick fix for this because our vendor extensions kept getting deleted.

If you are already have something in the works don't worry about merging this, but I thought I should share in any case.

Basically instead of assuming the first child is always a "#text" node, this fix will take all of the #text nodes in the vendor extension and store the merged value in the `value_` member.  All other nodes will be stored as normal in the `children_` member.

I also fixed some compilation issues relating to implicit casting of ascii strings to QStrings