### PR TITLE
[CORRECTIVE] .qmake.conf: fix python undefined reference

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -15,8 +15,8 @@ PYTHON_CONFIG=python3-config
 # if the compilation fails.
 # PYTHON_LIBS contains the library names and locations (-l and -L flags) needed in linking
 # with Python.
-PYTHON_C_FLAGS=$$system($$PYTHON_CONFIG --cflags | grep -o -e "-I[^[:space:]]*" | uniq)
-PYTHON_LIBS=$$system($$PYTHON_CONFIG --ldflags | grep -o -e "-[lL][^[:space:]]*")
+PYTHON_C_FLAGS=$$system($$PYTHON_CONFIG --cflags --embed | grep -o -e "-I[^[:space:]]*" | uniq)
+PYTHON_LIBS=$$system($$PYTHON_CONFIG --ldflags --embed | grep -o -e "-[lL][^[:space:]]*")
 
 
 #


### PR DESCRIPTION
Code that embeds Python (rather than building an extension module)
needs to pass --embed to any python3-config --ldflags or --libs
invocation to build above Python 3.8.

More information:
https://docs.python.org/3.8/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
https://github.com/kactus2/kactus2dev/runs/5092829434?check_suite_focus=true

```bash
/usr/bin/ld: IOCatcher.cpp:(.text+0x272): undefined reference to `PyType_Ready'
/usr/bin/ld: IOCatcher.cpp:(.text+0x28b): undefined reference to `PyModule_Create2'
/usr/bin/ld: IOCatcher.cpp:(.text+0x2b5): undefined reference to `PyModule_AddObject'
/usr/bin/ld: IOCatcher.cpp:(.text+0x2d7): undefined reference to `PyModule_AddObject'
/usr/bin/ld: IOCatcher.cpp:(.text+0x2fb): undefined reference to `_Py_Dealloc'
/usr/bin/ld: IOCatcher.cpp:(.text+0x31d): undefined reference to `_Py_Dealloc'
/usr/bin/ld: IOCatcher.cpp:(.text+0x340): undefined reference to `_Py_Dealloc'
/usr/bin/ld: IOCatcher.cpp:(.text+0x358): undefined reference to `_Py_Dealloc'
```