### PR TITLE
Fixes Linker Error, and deprecation warning

### DIFF
--- a/Plugins/MCAPICodeGenerator/MCAPICodeGenerator.pro
+++ b/Plugins/MCAPICodeGenerator/MCAPICodeGenerator.pro
@@ -17,7 +17,7 @@ INCLUDEPATH += ./../.. \
     $(QTDIR)/../qttools/include 
 
 LIBS += -L"./../../executable" \
-    -lIPXACTmodels -lKactus2
+    -lIPXACTmodels
 
 DESTDIR = ../../executable/Plugins
 

--- a/Plugins/VHDLGenerator/VHDLGenerator.pro
+++ b/Plugins/VHDLGenerator/VHDLGenerator.pro
@@ -15,7 +15,7 @@ INCLUDEPATH += ./../.. \
     . \
     $(QTDIR)/../qttools/include 
 LIBS += -L"./../../executable" \
-    -lIPXACTmodels -lKactus2
+    -lIPXACTmodels
 
 DESTDIR = ../../executable/Plugins
 

--- a/PythonAPI/PythonAPI.pro
+++ b/PythonAPI/PythonAPI.pro
@@ -9,8 +9,8 @@ CONFIG += c++11 release dll
 DEFINES += PYTHONAPI_LIB
 QT += core gui widgets xml
 LIBS += -L"$(SolutionDir)x64/executable" \
-    -L$$(PWD)/../executable -lIPXACTmodels \
-    -L$$(PWD)/../executable -lKactus2
+    -L$$(PWD)/../executable -lIPXACTmodels
+
 DEPENDPATH += ..
 INCLUDEPATH += ..
 MOC_DIR += ./GeneratedFiles

--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ print_success() {
 # Generate compressed help files.
 echo "Generating compressed help files..."
 ${QTBIN_PATH}qhelpgenerator Help/kactus2help.qhp -o Help/Kactus2Help.qch
-${QTBIN_PATH}qcollectiongenerator Help/kactus2help.qhcp -o Help/Kactus2Help.qhc
+${QTBIN_PATH}qhelpgenerator Help/kactus2help.qhcp -o Help/Kactus2Help.qhc
 
 if command -v ${QTBIN_PATH}qtchooser >/dev/null 2>&1; then
    #Run qmake using qtchooser.


### PR DESCRIPTION
* Fixes Linker error in Fedora 35:
  "cannot use executable file './../../executable/libKactus2.so' as input to a link"
* Fixes Deprecation warning for 'qcollectiongenerator' with Qt5.15.2

**Note:** 
* Used `LD_LIBRARY_PATH` for libraries.
* Followed the steps mentioned under the section:[Troubleshooting for Python API](https://github.com/kactus2/kactus2dev#troubleshooting-for-python-api) for fixing the PythonAPI import issue.