### PR TITLE
[PERFECTIVE] Optimize the default value of the verilog input port

### DIFF
--- a/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
+++ b/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
@@ -17,6 +17,8 @@
 #include <IPXACTmodels/Component/Port.h>
 #include <IPXACTmodels/Component/BusInterface.h>
 
+#include <QRegularExpression>
+
 namespace
 {
     const int ALL_BITS = -1; //! Indicator for connecting all bits in a connection.
@@ -232,6 +234,13 @@ QString ComponentInstanceVerilogWriter::assignmentForInstancePort(QSharedPointer
     {
         if (mPort->port_->getDirection() == DirectionTypes::IN)
         {
+            QRegularExpression re(R"""(^(\b((\d+'(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))|(\B(('(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))|(\b([0-9_])+)$)""");
+            QRegularExpressionMatch match = re.match(mPort->port_->getDefaultValue().trimmed());
+            if (match.hasMatch()) {
+                // If it's canonical Number Literals, keep it as is.
+                return mPort->port_->getDefaultValue();
+            }
+            // If it still doesn't work, use the calculated value.
             return mPort->defaultValue_;
         }
 

--- a/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
+++ b/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
@@ -234,7 +234,7 @@ QString ComponentInstanceVerilogWriter::assignmentForInstancePort(QSharedPointer
     {
         if (mPort->port_->getDirection() == DirectionTypes::IN)
         {
-            QRegularExpression re(R"""(^(\b((\d+'(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))|(\B(('(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))|(\b([0-9_])+)$)""");
+            QRegularExpression re(R"""(^(\b((\d+'(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))|(\B(('(s|S){0,1}(b|h|o|d|B|H|O|D))[0-9xzXZa-fA-F_]+))$)""");
             QRegularExpressionMatch match = re.match(mPort->port_->getDefaultValue().trimmed());
             if (match.hasMatch()) {
                 // If it's canonical Number Literals, keep it as is.

--- a/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
+++ b/Plugins/VerilogGenerator/ComponentInstanceVerilogWriter/ComponentInstanceVerilogWriter.cpp
@@ -247,10 +247,10 @@ QString ComponentInstanceVerilogWriter::assignmentForInstancePort(QSharedPointer
                 bool boundsFirstOk = false;
                 bool boundsSecondOk = false;
                 bool defaultValueOk = false;
-                unsigned long boundsFirst = mPort->vectorBounds_.first.toULong(&boundsFirstOk);
-                unsigned long boundsSecond = mPort->vectorBounds_.second.toULong(&boundsSecondOk);
-                unsigned long defaultValue = mPort->defaultValue_.toULong(&defaultValueOk);
-                unsigned long vectorWidth = 0;
+                qint64 boundsFirst(mPort->vectorBounds_.first.toULongLong(&boundsFirstOk));
+                qint64 boundsSecond(mPort->vectorBounds_.second.toULongLong(&boundsSecondOk));
+                qint64 defaultValue(mPort->defaultValue_.toULongLong(&defaultValueOk));
+                qint64 vectorWidth(0);
                 if (defaultValueOk)
                 {
                     if (mPort->vectorBounds_.first == mPort->vectorBounds_.second)
@@ -262,12 +262,12 @@ QString ComponentInstanceVerilogWriter::assignmentForInstancePort(QSharedPointer
                     if (boundsFirstOk && boundsSecondOk && boundsFirst > boundsSecond)
                     {
                         // Calculate width based on legal bounds.
-                        vectorWidth = boundsFirst - boundsSecond + 1;
+                        vectorWidth = abs(boundsFirst - boundsSecond) + 1;
                     }
 
                     if (vectorWidth > 0)
                     {
-                        //At this point, the conversion is successful.
+                        // At this point, the conversion is successful.
                         if (vectorWidth < 8)
                         {
                             // If the width is less than 8 bits, use the 'b format


### PR DESCRIPTION
The current Port default value forces decimal after writing out verilog and loses width and sign information. This is lax in some cases and may introduce some coding style lint warnings.

To solve this problem I made some improvements, which will carry the corresponding width information according to the port width in the default value, making the synthesizer happy.

E.g.:

Set default value ``40'h4000000000`` to port ``pad_cpu_apb_base``.   

![image](https://user-images.githubusercontent.com/394260/190595815-c0c20766-f4e5-4dff-870a-ccffd0611856.png)


Before:

```verilog
// Generated verilog results
...
        .pad_cpu_apb_base    (274877906944),
        .pad_cpu_rst_b       (),
        .pad_cpu_rvba        (cpu0_pad_cpu_rvba),
        .pad_cpu_sys_cnt     (),
        .pad_plic_int_cfg    (),
        .pad_plic_int_vld    (),
        .pad_tdt_dm_core_unavail(0),
        .pad_yy_dft_clk_rst_b(1),
        .pad_yy_icg_scan_en  (0),
        .pad_yy_mbist_mode   (0),
        .pad_yy_scan_enable  (0),
        .pad_yy_scan_mode    (0),
        .pad_yy_scan_rst_b   (1),
...
```

After:

```verilog
// Generated verilog results
...
        .axim_clk_en         (),
        .pad_cpu_apb_base    (40'h4000000000),
        .pad_cpu_rst_b       (),
        .pad_cpu_rvba        (cpu0_pad_cpu_rvba),
        .pad_cpu_sys_cnt     (),
        .pad_plic_int_cfg    (),
        .pad_plic_int_vld    (),
        .pad_tdt_dm_core_unavail(1'b0),
        .pad_yy_dft_clk_rst_b(1'b1),
        .pad_yy_icg_scan_en  (1'b0),
        .pad_yy_mbist_mode   (1'b0),
        .pad_yy_scan_enable  (1'b0),
        .pad_yy_scan_mode    (1'b0),
        .pad_yy_scan_rst_b   (1'b1),
...
```

This is easier to read and solves a lint problem.

If you want it to be in decimal, then write the verilog canonical number literals in decimal directly, such as 64'd314159265, and then you can keep the decimal.

If you want this to be a signed number, write signed verilog canonical number literals, such as 4'sd15, so that you can keep the signed number default value when outputting verilog.
