### PR TITLE
[CORRECTIVE] add missing <QSharedPointer> include to fix QT6.6.0 build

### DIFF
--- a/editors/HWDesign/undoCommands/HWComponentAddCommand.h
+++ b/editors/HWDesign/undoCommands/HWComponentAddCommand.h
@@ -12,10 +12,11 @@
 #ifndef HWCOMPONENTADDCOMMAND_H
 #define HWCOMPONENTADDCOMMAND_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
-#include <QString>
 #include <QObject>
+#include <QSharedPointer>
+#include <QString>
+#include <QUndoCommand>
 
 class IGraphicsItemStack;
 class ComponentItem;

--- a/editors/SystemDesign/UndoCommands/ApiConnectionDeleteCommand.h
+++ b/editors/SystemDesign/UndoCommands/ApiConnectionDeleteCommand.h
@@ -12,9 +12,10 @@
 #ifndef APICONNECTIONDELETECOMMAND_H
 #define APICONNECTIONDELETECOMMAND_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
 #include <QObject>
+#include <QSharedPointer>
+#include <QUndoCommand>
 
 class ApiGraphicsConnection;
 

--- a/editors/SystemDesign/UndoCommands/ComConnectionDeleteCommand.h
+++ b/editors/SystemDesign/UndoCommands/ComConnectionDeleteCommand.h
@@ -12,9 +12,10 @@
 #ifndef COMCONNECTIONDELETECOMMAND_H
 #define COMCONNECTIONDELETECOMMAND_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
 #include <QObject>
+#include <QSharedPointer>
+#include <QUndoCommand>
 
 class ComGraphicsConnection;
 

--- a/editors/SystemDesign/UndoCommands/SWInterfaceDeleteCommand.h
+++ b/editors/SystemDesign/UndoCommands/SWInterfaceDeleteCommand.h
@@ -12,9 +12,10 @@
 #ifndef SWINTERFACEDELETECOMMAND_H
 #define SWINTERFACEDELETECOMMAND_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
 #include <QObject>
+#include <QSharedPointer>
+#include <QUndoCommand>
 
 class IGraphicsItemStack;
 class SWInterfaceItem;

--- a/editors/SystemDesign/UndoCommands/SystemComponentDeleteCommand.h
+++ b/editors/SystemDesign/UndoCommands/SystemComponentDeleteCommand.h
@@ -12,9 +12,10 @@
 #ifndef SYSTEMCOMPONENTDELETECOMMAND_H
 #define SYSTEMCOMPONENTDELETECOMMAND_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
 #include <QObject>
+#include <QSharedPointer>
+#include <QUndoCommand>
 
 class ComponentItem;
 class IGraphicsItemStack;

--- a/editors/SystemDesign/UndoCommands/SystemDeleteCommands.h
+++ b/editors/SystemDesign/UndoCommands/SystemDeleteCommands.h
@@ -12,9 +12,10 @@
 #ifndef SYSTEMDELETECOMMANDS_H
 #define SYSTEMDELETECOMMANDS_H
 
-#include <QUndoCommand>
 #include <QGraphicsScene>
 #include <QObject>
+#include <QSharedPointer>
+#include <QUndoCommand>
 
 class GraphicsConnection;
 class GraphicsColumnLayout;


### PR DESCRIPTION
- add missing #include <QSharedPointer> to fix incomplete type about QSharedPointer