### PR TITLE
[CORRECTIVE] Fix incomplete QObject type and resolves errors

### DIFF
--- a/IPXACTmodels/Component/validators/FieldReferenceValidator.h
+++ b/IPXACTmodels/Component/validators/FieldReferenceValidator.h
@@ -16,6 +16,8 @@
 
 #include <IPXACTmodels/Component/FieldReference.h>
 
+#include <QObject>
+
 namespace FieldReferenceValidator
 {
     /*!

--- a/IPXACTmodels/Component/validators/MemoryArrayValidator.h
+++ b/IPXACTmodels/Component/validators/MemoryArrayValidator.h
@@ -16,6 +16,8 @@
 
 #include <KactusAPI/include/SystemVerilogExpressionParser.h>
 
+#include <QObject>
+
 class MemoryArray;
 
 class IPXACTMODELS_EXPORT MemoryArrayValidator


### PR DESCRIPTION
Under Linux/QT 6.6.1, there are compilation errors due to incomplete type 'QObject' used in nested name specifier in various validator components:

```bash
Component/validators/FieldReferenceValidator.cpp: In function ‘void FieldReferenceValidator::findErrorsIn(QStringList&, QSharedPointer<FieldReference>, const QString&)’:
Component/validators/FieldReferenceValidator.cpp:43:35: error: incomplete type ‘QObject’ used in nested name specifier
   43 |         errorList.append(QObject::tr("Field reference in %1 cannot contain both an address space reference"
      |                                   ^~
Component/validators/FieldReferenceValidator.cpp:49:35: error: incomplete type ‘QObject’ used in nested name specifier
   49 |         errorList.append(QObject::tr("Field reference in %1 must contain a reference to a field.").arg(context));
      |                                   ^~
x86_64-pc-linux-gnu-g++ -c -march=znver2 -mtune=znver2 -O2 -pipe -std=gnu++1z -Wall -Wextra -D_REENTRANT -fPIC -DIPXACTMODELS_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_DEBUG -DQT_GUI_LIB -DQT_XML_LIB -DQT_CORE_LIB -I. -IGeneratedFiles -I. -I./GeneratedFiles/Release -I.. -I/usr/include/qt6 -I/usr/include/qt6/QtGui -I/usr/include/qt6/QtXml -I/usr/include/qt6/QtCore -IGeneratedFiles/release -I/usr/lib64/qt6/mkspecs/linux-g++ -o release/PowerDomainValidator.o Component/validators/PowerDomainValidator.cpp
make[1]: *** [Makefile:7443: release/FieldReferenceValidator.o] Error 1
make[1]: *** Waiting for unfinished jobs....
Component/validators/MemoryArrayValidator.cpp: In member function ‘void MemoryArrayValidator::findErrorsIn(QStringList&, QSharedPointer<MemoryArray>, const QString&) const’:
Component/validators/MemoryArrayValidator.cpp:40:35: error: incomplete type ‘QObject’ used in nested name specifier
   40 |         errorList.append(QObject::tr("No dimensions defined for memory array in %1").arg(context));
      |                                   ^~
Component/validators/MemoryArrayValidator.cpp:55:35: error: incomplete type ‘QObject’ used in nested name specifier
   55 |         errorList.append(QObject::tr("One or more dimensions of the memory array in %1 have an invalid value.")
      |                                   ^~
Component/validators/MemoryArrayValidator.cpp:61:35: error: incomplete type ‘QObject’ used in nested name specifier
   61 |         errorList.append(QObject::tr("Memory array in %1 has an invalid stride value.").arg(context));
      |                                   ^~
make[1]: *** [Makefile:7772: release/MemoryArrayValidator.o] Error 1
```

- Added missing ``#include <QObject>`` in ``FieldReferenceValidator.h``
- Added missing ``#include <QObject>`` in ``MemoryArrayValidator.h``
- Resolves compilation errors due to incomplete type ``'QObject'`` used in nested name specifier in various validator components